### PR TITLE
[bugfix] nonce should be url friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "supertest": "^4.0.2"
   },
   "resolutions": {
-    "parse-path": "^5.0.0"
+    "parse-path": "^5.0.0",
+    "terser": "^5.14.2"
   },
   "files": [
     "dist",

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -47,7 +47,7 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
     const domain = (domainOpt ? domainOpt : 'https://app.okayhq.com').trim().replace(/\/+$/, '');
 
     // securely generate a nonce and TS, then sign the payload
-    const nonce = crypto.randomBytes(16).toString('base64');
+    const nonce = crypto.randomBytes(16).toString('base64url');
     const ts = new Date().toISOString();
     const signature = crypto
       .createHmac('sha1', secret)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10241,10 +10241,10 @@ terser-webpack-plugin@^5.1.3:
     serialize-javascript "^6.0.0"
     terser "^5.7.2"
 
-terser@^5.10.0, terser@^5.7.2:
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.1.tgz#7c95eec36436cb11cf1902cc79ac564741d19eca"
-  integrity sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==
+terser@^5.10.0, terser@^5.14.2, terser@^5.7.2:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.15.0.tgz#e16967894eeba6e1091509ec83f0c60e179f2425"
+  integrity sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
- invalid URL symbols like the `+` symbol are converted to a whitespace in the url, causing mismatching signatures between client and server
- also fix security vuln in library & bump version